### PR TITLE
Contextual placeholder arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Lazy-load Rails partials via CableReady
   - [HTML Options](#html-options)
   - [Eager Loading](#eager-loading)
   - [Broadcast Partials Individually](#broadcast-partials-individually)
+  - [Contextual Placeholder Arguments](#contextual-placeholder-arguments)
 - [Events](#events)
 - [Installation](#installation)
   - [Manual Installation](#manual-installation)
@@ -185,6 +186,28 @@ For collections, however, you can opt into individual broadcasts by specifying `
 <%= futurize @posts, broadcast_each: true, extends: :tr do %>
   <div class="placeholder"</td>
 <% end %>
+```
+
+## Contextual Placeholder Arguments
+
+For individual models or arbitrary collections, you can pass `record` and `index` to the placeholder block as arguments:
+
+```erb
+<%= futurize @post, extends: :div do |post| %>
+  <div><%= post.title %></div>
+<% end %>
+```
+
+```erb
+<%= futurize @posts, extends: :tr do |post, index| %>
+  <td><%= index + 1 %></td><td><%= post.title %></td>
+<% end %>
+```
+
+```erb
+<%= futurize partial: "users/user", collection: users, extends: "tr" do |user, index| %>
+  <td><%= index + 1 %></td><td><%= user.name %></td>
+<% end >
 ```
 
 ## Events

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -41,8 +41,8 @@ module Futurism
     end
 
     def futurize_active_record(records, extends:, **options, &block)
-      Array(records).map { |record|
-        placeholder = capture(&block) if block_given?
+      Array(records).map.with_index { |record, index|
+        placeholder = capture(record, index, &block) if block_given?
 
         WrappingFuturismElement.new(extends: extends, options: options.merge(model: record), placeholder: placeholder).render
       }.join.html_safe

--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -22,16 +22,19 @@ module Futurism
     end
 
     def futurize_with_options(extends:, **options, &block)
-      placeholder = capture(&block) if block_given?
-
       collection = options.delete(:collection)
       if collection.nil?
+        placeholder = capture(&block) if block_given?
+
         WrappingFuturismElement.new(extends: extends, placeholder: placeholder, options: options).render
       else
         collection_class_name = collection.try(:klass).try(:name) || collection.first.class.to_s
         as = options.delete(:as) || collection_class_name.underscore
         broadcast_each = options.delete(:broadcast_each) || false
+
         collection.each_with_index.map { |record, index|
+          placeholder = capture(record, index, &block) if block_given?
+
           WrappingFuturismElement.new(extends: extends, placeholder: placeholder, options: options.deep_merge(
             broadcast_each: broadcast_each,
             locals: {as.to_sym => record, "#{as}_counter".to_sym => index}

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -144,6 +144,16 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "2. Ipsum", element.children.last.children.first.text
   end
 
+  test "renders contextual placeholder arguments for any kind of collection" do
+    Post.create title: "Lorem"
+    Post.create title: "Ipsum"
+
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true, extends: :div) { |post, index| "#{index + 1}. #{post.title}" })
+
+    assert_equal "1. Lorem", element.children.first.children.first.text
+    assert_equal "2. Ipsum", element.children.last.children.first.text
+  end
+
   def verifier
     Futurism::MessageVerifier.message_verifier
   end

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -126,6 +126,24 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "true", element.children.last["data-broadcast-each"]
   end
 
+  test "renders contextual placeholder arguments for an ActiveRecord::Base" do
+    post = Post.create title: "Lorem"
+
+    element = Nokogiri::HTML.fragment(futurize(post, extends: :div) { |post| post.title })
+
+    assert_equal "Lorem", element.children.first.children.first.text
+  end
+
+  test "renders contextual placeholder arguments for an ActiveRecord::Relation" do
+    Post.create title: "Lorem"
+    Post.create title: "Ipsum"
+
+    element = Nokogiri::HTML.fragment(futurize(Post.all, broadcast_each: true, extends: :div) { |post, index| "#{index + 1}. #{post.title}" })
+
+    assert_equal "1. Lorem", element.children.first.children.first.text
+    assert_equal "2. Ipsum", element.children.last.children.first.text
+  end
+
   def verifier
     Futurism::MessageVerifier.message_verifier
   end


### PR DESCRIPTION
# Feature

## Description

Passes a `record` and `index` arguments to any `futurize` placeholder block rendered either for an `ActiveRecord::Base` or any type of collection.

I.e. you can do

```erb
<%= futurize Post.all .... do |post, index| %>
  <li><%= index + 1 %>. <%= post.title %></li>
<% end %>
```

Fixes #104 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
