### PR TITLE
fix: run polyfill before eventListeners

### DIFF
--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -73,12 +73,11 @@ const restorePlaceholders = e => {
 }
 
 export const initializeElements = () => {
+  polyfillCustomElements()
   document.addEventListener('DOMContentLoaded', defineElements)
   document.addEventListener('turbo:load', defineElements)
   document.addEventListener('turbo:before-cache', restorePlaceholders)
   document.addEventListener('turbolinks:load', defineElements)
   document.addEventListener('turbolinks:before-cache', restorePlaceholders)
   document.addEventListener('cable-ready:after-outer-html', cachePlaceholders)
-
-  polyfillCustomElements()
 }


### PR DESCRIPTION
## Possible bug fix

- Possibly related to #72 , but i could see an issue where the events are firing before the polyfill is loaded.

## Description

Run polyfill before defining elements

## Why should this be added

🤷 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
