### PR TITLE
Listen to cable-ready:after-update events and re-request the partial

### DIFF
--- a/javascript/elements/futurism_element.js
+++ b/javascript/elements/futurism_element.js
@@ -2,12 +2,14 @@
 
 import {
   extendElementWithIntersectionObserver,
-  extendElementWithEagerLoading
+  extendElementWithEagerLoading,
+  extendElementWithCableReadyUpdatesFor
 } from './futurism_utils'
 
 export default class FuturismElement extends HTMLElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
+    extendElementWithCableReadyUpdatesFor(this)
   }
 }

--- a/javascript/elements/futurism_li.js
+++ b/javascript/elements/futurism_li.js
@@ -2,12 +2,14 @@
 
 import {
   extendElementWithIntersectionObserver,
-  extendElementWithEagerLoading
+  extendElementWithEagerLoading,
+  extendElementWithCableReadyUpdatesFor
 } from './futurism_utils'
 
 export default class FuturismLI extends HTMLLIElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
+    extendElementWithCableReadyUpdatesFor(this)
   }
 }

--- a/javascript/elements/futurism_table_row.js
+++ b/javascript/elements/futurism_table_row.js
@@ -2,12 +2,14 @@
 
 import {
   extendElementWithIntersectionObserver,
-  extendElementWithEagerLoading
+  extendElementWithEagerLoading,
+  extendElementWithCableReadyUpdatesFor
 } from './futurism_utils'
 
 export default class FuturismTableRow extends HTMLTableRowElement {
   connectedCallback () {
     extendElementWithIntersectionObserver(this)
     extendElementWithEagerLoading(this)
+    extendElementWithCableReadyUpdatesFor(this)
   }
 }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -62,3 +62,9 @@ export const extendElementWithEagerLoading = element => {
     dispatchAppearEvent(element)
   }
 }
+
+export const extendElementWithCableReadyUpdatesFor = (element) => {
+  element.addEventListener('cable-ready:after-update', () => {
+    dispatchAppearEvent(element);
+  });
+}


### PR DESCRIPTION
# Type of PR
feature / enhancement

## Description

By listening to [cable-ready:after-update](https://github.com/stimulusreflex/cable_ready/blob/3a96f289ddccb311d8dde52564d3d25a24db4d2b/javascript/elements/updates_for_element.js#L93) events we are able to re-request the partial from the server. Allowing the server to serve the original content (without the need for unless) and stay fast. 

## Why should this be added

The server can serve it's original response without needing to include the futurismed partials which can potentially be slow to render. (That is probably the reason why futurism was chosen, at least it is in my case).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing

This is currently a proposal / draft. I still need to try/test this locally and remove the found caveats.
I would like to get feedback on the proposed code in order to improve it / check if this would be the correct way to implement this enhancement.

Potential caveats are:

- CableReady morphs the inner part of the futurism element, causing it to show the temporary loader div.
- The listener is potentially added multiple times on the element, causing it to request the partial multiple times (is covered by the debouncer, but I would like to avoid this)
- Shall we make this an opt-out enhancement or do we want to add this as an opt-in? (adding a data-attribute to the element for example in order to opt out/in)