### PR TITLE
Default :extends option

### DIFF
--- a/lib/futurism/helpers.rb
+++ b/lib/futurism/helpers.rb
@@ -1,6 +1,6 @@
 module Futurism
   module Helpers
-    def futurize(records_or_string = nil, extends:, **options, &block)
+    def futurize(records_or_string = nil, extends: :div, **options, &block)
       if (Rails.env.test? && Futurism.skip_in_test) || options[:unless]
         if records_or_string.nil?
           return render(**options)

--- a/test/cable/channel_test.rb
+++ b/test/cable/channel_test.rb
@@ -54,7 +54,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "broadcasts a rendered model after receiving signed params" do
     with_mocked_renderer do |mock_renderer|
       post = Post.create title: "Lorem"
-      fragment = Nokogiri::HTML.fragment(futurize(post, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize(post) {})
       signed_params_array = fragment.children.map { |element| element["data-signed-params"] }
       sgids = fragment.children.map { |element| element["data-sgid"] }
       subscribe
@@ -72,7 +72,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
       post1 = Post.create(title: "Lorem")
       post2 = Post.create(title: "Ipsum")
 
-      fragment = Nokogiri::HTML.fragment(futurize(Post.all, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize(Post.all) {})
       signed_params_array = fragment.children.map { |element| element["data-signed-params"] }
       sgids = fragment.children.map { |element| element["data-sgid"] }
       subscribe
@@ -90,7 +90,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "broadcasts a rendered partial after receiving signed params" do
     with_mocked_renderer do |mock_renderer|
       post = Post.create title: "Lorem"
-      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}) {})
       signed_params = fragment.children.first["data-signed-params"]
       subscribe
 
@@ -106,7 +106,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "broadcasts a rendered partial after receiving the shorthand syntax" do
     with_mocked_renderer do |mock_renderer|
       post = Post.create title: "Lorem"
-      fragment = Nokogiri::HTML.fragment(futurize("posts/card", post: post, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize("posts/card", post: post) {})
       signed_params = fragment.children.first["data-signed-params"]
       subscribe
 
@@ -120,7 +120,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "broadcasts a rendered partial after receiving the shorthand syntax with html options" do
     with_mocked_renderer do |mock_renderer|
       post = Post.create title: "Lorem"
-      fragment = Nokogiri::HTML.fragment(futurize("posts/card", post: post, extends: :div, html_options: {style: "color: green"}) {})
+      fragment = Nokogiri::HTML.fragment(futurize("posts/card", post: post, html_options: {style: "color: green"}) {})
       signed_params = fragment.children.first["data-signed-params"]
       subscribe
 
@@ -136,7 +136,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     with_mocked_renderer do |mock_renderer|
       Post.create title: "Lorem"
       Post.create title: "Ipsum"
-      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, extends: :div, locals: {important_local: "needed to render"}) {})
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, locals: {important_local: "needed to render"}) {})
       subscribe
 
       mock_renderer
@@ -157,7 +157,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     with_mocked_renderer do |mock_renderer|
       ActionItem.create description: "Do this"
       ActionItem.create description: "Do that"
-      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: ActionItem.all, extends: :div, locals: {important_local: "needed to render"}) {})
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: ActionItem.all, locals: {important_local: "needed to render"}) {})
 
       subscribe
 
@@ -179,7 +179,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     with_mocked_renderer do |mock_renderer|
       Post.create title: "Lorem"
       Post.create title: "Ipsum"
-      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, as: :post_item, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, as: :post_item) {})
       subscribe
 
       mock_renderer.expect(:render, "<tag></tag>", [partial: "posts/card", locals: {post_item: Post.first, post_item_counter: 0}])
@@ -198,7 +198,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
     with_mocked_cable_ready do |cable_ready_mock|
       Post.create title: "Lorem"
       Post.create title: "Ipsum"
-      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, broadcast_each: true, extends: :div, locals: {important_local: "needed to render"}) {})
+      fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, broadcast_each: true, locals: {important_local: "needed to render"}) {})
       subscribe
 
       signed_params_1 = fragment.children.first["data-signed-params"]
@@ -212,7 +212,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   end
 
   test "broadcasts an inline rendered text" do
-    fragment = Nokogiri::HTML.fragment(futurize(inline: "<%= 1 + 2 %>", extends: :div) {})
+    fragment = Nokogiri::HTML.fragment(futurize(inline: "<%= 1 + 2 %>") {})
     signed_params = fragment.children.first["data-signed-params"]
     subscribe(channel: "Futurism::Channel")
 
@@ -223,7 +223,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
 
   test "broadcasts a correctly formed path" do
     post = Post.create title: "Lorem"
-    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, extends: :div) {})
+    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}) {})
     signed_params = fragment.children.first["data-signed-params"]
     subscribe(channel: "Futurism::Channel")
 
@@ -237,7 +237,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   test "passes parsed params to controller render" do
     with_mocked_renderer do |mock_renderer|
       post = Post.create title: "Lorem"
-      fragment = Nokogiri::HTML.fragment(futurize(post, extends: :div) {})
+      fragment = Nokogiri::HTML.fragment(futurize(post) {})
       signed_params_array = fragment.children.map { |element| element["data-signed-params"] }
       sgids = fragment.children.map { |element| element["data-sgid"] }
       urls = Array.new(fragment.children.length, "http://www.example.org/route?param1=true&param2=1234")
@@ -252,7 +252,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
   end
 
   test "renders error message when rendering invalid partial error" do
-    fragment = Nokogiri::HTML.fragment(futurize(partial: "INVALID/PARTIAL", extends: :div) {})
+    fragment = Nokogiri::HTML.fragment(futurize(partial: "INVALID/PARTIAL") {})
     signed_params = fragment.children.first["data-signed-params"]
     subscribe(channel: "Futurism::Channel")
 
@@ -265,7 +265,7 @@ class Futurism::ChannelTest < ActionCable::Channel::TestCase
 
   test "renders error message when wrong variable name" do
     Post.create title: "Lorem"
-    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, as: :wrong_variable_name, extends: :div) {})
+    fragment = Nokogiri::HTML.fragment(futurize(partial: "posts/card", collection: Post.all, as: :wrong_variable_name) {})
     signed_params = fragment.children.first["data-signed-params"]
     subscribe(channel: "Futurism::Channel")
 

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -54,6 +54,24 @@ class Futurism::HelperTest < ActionView::TestCase
     assert extract_params(element.children.first["data-signed-params"])[:locals][:post].new_record?
   end
 
+  test "renders futurism-element by default" do
+    element = Nokogiri::HTML.fragment(futurize("posts/card", post: Post.new) {})
+
+    assert_equal element.children.first.name, "futurism-element"
+  end
+
+  test "renders futurism-table-row or futurism-li if specified via extends option" do
+    element = Nokogiri::HTML.fragment(futurize("posts/card", post: Post.new, extends: :tr) {})
+
+    assert_equal element.children.first.name, "tr"
+    assert_equal element.children.first["is"], "futurism-table-row"
+
+    element = Nokogiri::HTML.fragment(futurize("posts/card", post: Post.new, extends: :li) {})
+
+    assert_equal element.children.first.name, "li"
+    assert_equal element.children.first["is"], "futurism-li"
+  end
+
   # PORO that is serializable/de-serializable
   class GlobalIdableEntity
     include GlobalID::Identification

--- a/test/helper/helper_test.rb
+++ b/test/helper/helper_test.rb
@@ -8,7 +8,7 @@ class Futurism::HelperTest < ActionView::TestCase
   test "renders html options with data attributes" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {class: "absolute inset-0", data: {controller: "test"}}) {})
+    element = Nokogiri::HTML.fragment(futurize(post, html_options: {class: "absolute inset-0", data: {controller: "test"}}) {})
 
     assert_equal "futurism-element", element.children.first.name
     assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
@@ -17,7 +17,7 @@ class Futurism::HelperTest < ActionView::TestCase
     assert_equal "absolute inset-0", element.children.first["class"]
 
     params = {partial: "posts/card", locals: {post: post}}
-    element = Nokogiri::HTML.fragment(futurize(**params.merge({html_options: {class: "flex justify-center", data: {action: "test#click"}}, extends: :div})) {})
+    element = Nokogiri::HTML.fragment(futurize(**params.merge({html_options: {class: "flex justify-center", data: {action: "test#click"}}})) {})
 
     assert_equal "futurism-element", element.children.first.name
     assert_nil element.children.first["data-sgid"]
@@ -31,7 +31,7 @@ class Futurism::HelperTest < ActionView::TestCase
   test "renders html options with data attributes with multi-word object" do
     action_item = ActionItem.create description: "Do this"
 
-    element = Nokogiri::HTML.fragment(futurize(action_item, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(action_item) {})
 
     assert_equal "futurism-element", element.children.first.name
     assert_equal action_item, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
@@ -40,7 +40,7 @@ class Futurism::HelperTest < ActionView::TestCase
   test "ensures signed_params and sgid are not overwritable" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, html_options: {data: {controller: "test", sgid: "test", signed_params: "test"}}) {})
+    element = Nokogiri::HTML.fragment(futurize(post, html_options: {data: {controller: "test", sgid: "test", signed_params: "test"}}) {})
 
     assert_equal post, GlobalID::Locator.locate_signed(element.children.first["data-sgid"])
     assert_equal sign_params({data: {controller: "test"}}), element.children.first["data-signed-params"]
@@ -49,7 +49,7 @@ class Futurism::HelperTest < ActionView::TestCase
   test "allows to specify a new ActiveRecord record" do
     post = Post.new
 
-    element = Nokogiri::HTML.fragment(futurize("posts/form", post: post, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize("posts/form", post: post) {})
 
     assert extract_params(element.children.first["data-signed-params"])[:locals][:post].new_record?
   end
@@ -69,7 +69,7 @@ class Futurism::HelperTest < ActionView::TestCase
 
   test "allows to specify any GlobalId-able entity" do
     entity = GlobalIdableEntity.new
-    element = Nokogiri::HTML.fragment(futurize("posts/form", entity: entity, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize("posts/form", entity: entity) {})
 
     assert_equal "gid://dummy/Futurism::HelperTest::GlobalIdableEntity/fake-id", extract_params(element.children.first["data-signed-params"])[:locals][:entity]
   end
@@ -77,33 +77,33 @@ class Futurism::HelperTest < ActionView::TestCase
   test "does not render an eager loading data attribute per default" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(post) {})
 
     refute_equal "true", element.children.first["data-eager"]
 
-    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}) {})
     refute_equal "true", element.children.first["data-eager"]
   end
 
   test "renders an eager loading data attribute" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, eager: true) {})
+    element = Nokogiri::HTML.fragment(futurize(post, eager: true) {})
 
     assert_equal "true", element.children.first["data-eager"]
 
-    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, eager: true, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, eager: true) {})
     assert_equal "true", element.children.first["data-eager"]
   end
 
   test "renders an eager loading data attribute for an empty placeholder block" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div, eager: true) {})
+    element = Nokogiri::HTML.fragment(futurize(post, eager: true) {})
 
     assert_equal "true", element.children.first["data-eager"]
 
-    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}, extends: :div))
+    element = Nokogiri::HTML.fragment(futurize(partial: "posts/card", locals: {post: post}))
     assert_equal "true", element.children.first["data-eager"]
   end
 
@@ -111,7 +111,7 @@ class Futurism::HelperTest < ActionView::TestCase
     Post.create title: "Lorem"
     Post.create title: "Lorem2"
 
-    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all) {})
 
     assert_equal({post: "gid://dummy/Post/1", post_counter: 0}, Futurism::MessageVerifier.message_verifier.verify(element.children.first["data-signed-params"])[:locals])
     assert_equal({post: "gid://dummy/Post/2", post_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
@@ -121,7 +121,7 @@ class Futurism::HelperTest < ActionView::TestCase
     ActionItem.create description: "Do this"
     ActionItem.create description: "Do that"
 
-    element = Nokogiri::HTML.fragment(futurize(collection: ActionItem.all, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(collection: ActionItem.all) {})
 
     assert_equal({action_item: "gid://dummy/ActionItem/1", action_item_counter: 0}, Futurism::MessageVerifier.message_verifier.verify(element.children.first["data-signed-params"])[:locals])
     assert_equal({action_item: "gid://dummy/ActionItem/2", action_item_counter: 1}, Futurism::MessageVerifier.message_verifier.verify(element.children.last["data-signed-params"])[:locals])
@@ -131,7 +131,7 @@ class Futurism::HelperTest < ActionView::TestCase
     Post.create title: "Lorem"
     Post.create title: "Lorem2"
 
-    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true, extends: :div) {})
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true) {})
 
     assert_equal "true", element.children.first["data-broadcast-each"]
     assert_equal "true", element.children.last["data-broadcast-each"]
@@ -140,7 +140,7 @@ class Futurism::HelperTest < ActionView::TestCase
   test "renders contextual placeholder arguments for an ActiveRecord::Base" do
     post = Post.create title: "Lorem"
 
-    element = Nokogiri::HTML.fragment(futurize(post, extends: :div) { |post| post.title })
+    element = Nokogiri::HTML.fragment(futurize(post) { |post| post.title })
 
     assert_equal "Lorem", element.children.first.children.first.text
   end
@@ -149,7 +149,7 @@ class Futurism::HelperTest < ActionView::TestCase
     Post.create title: "Lorem"
     Post.create title: "Ipsum"
 
-    element = Nokogiri::HTML.fragment(futurize(Post.all, broadcast_each: true, extends: :div) { |post, index| "#{index + 1}. #{post.title}" })
+    element = Nokogiri::HTML.fragment(futurize(Post.all, broadcast_each: true) { |post, index| "#{index + 1}. #{post.title}" })
 
     assert_equal "1. Lorem", element.children.first.children.first.text
     assert_equal "2. Ipsum", element.children.last.children.first.text
@@ -159,7 +159,7 @@ class Futurism::HelperTest < ActionView::TestCase
     Post.create title: "Lorem"
     Post.create title: "Ipsum"
 
-    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true, extends: :div) { |post, index| "#{index + 1}. #{post.title}" })
+    element = Nokogiri::HTML.fragment(futurize(collection: Post.all, broadcast_each: true) { |post, index| "#{index + 1}. #{post.title}" })
 
     assert_equal "1. Lorem", element.children.first.children.first.text
     assert_equal "2. Ipsum", element.children.last.children.first.text


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Sets the default extends option to `:div`, which removes the need to repeatedly type `extends: :div` when using the futurize helper method :tada:

Fixes https://github.com/stimulusreflex/futurism/issues/127

## Why should this be added

Developer happiness; reduces boilerplate.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
