### PR TITLE
Use retries with extendElementWithEagerLoading

### DIFF
--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -59,6 +59,6 @@ export const extendElementWithIntersectionObserver = element => {
 export const extendElementWithEagerLoading = element => {
   if (element.dataset.eager === 'true') {
     if (element.observer) element.observer.disconnect()
-    dispatchAppearEvent(element)
+    callWithRetry(dispatchAppearEvent(element))
   }
 }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bugfix.

## Description

Resolves an issue with the `eager` option.

For elements using `IntersectionObserver` a retry mechanism is used for binding `dispatchAppearEvent` [here](https://github.com/stimulusreflex/futurism/blob/8d352a54a3f35bc2f7856774d6edefbd521d4fbf/javascript/elements/futurism_utils.js#L45). 

That same retry mechanism wasn't being used for elements using eager loading.

If it's not used, the calls to replace the element happen before the channel has been initialized on the client side, and the element doesn't get replaced.

Fixes #122 

## Why should this be added

Fixes loading elements with `eager: true`, and also fixes futurising partials without passing a block (#122).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
