### PR TITLE
Configurable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ Out of the box, Rails will prefix generated urls with `http://example.org` rathe
 
 to your environments.
 
+### Choosing the parent for Futurism::Channel
+
+By default Futurism::CHannel will inherit from ApplicationCable::Channel, you can change this by setting
+
+```ruby
+Futurism.configure do |config|
+  config.parent_channel = "CustomFuturismChannel"
+end
+
+```
+in config/initializers.
+
 ## Contributing
 
 ### Get local environment setup

--- a/app/channels/futurism/channel.rb
+++ b/app/channels/futurism/channel.rb
@@ -1,5 +1,5 @@
 module Futurism
-  class Channel < ActionCable::Channel::Base
+  class Channel < Futurism.configuration.parent_channel.constantize
     include CableReady::Broadcaster
 
     def stream_name

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -1,13 +1,15 @@
 require "rails"
+
+
 require "action_cable"
 require "cable_ready"
+require "futurism/configuration"
 require "futurism/engine"
 require "futurism/message_verifier"
 require "futurism/options_transformer"
 require "futurism/resolver/resources"
 require "futurism/resolver/controller"
 require "futurism/resolver/controller/renderer"
-require "futurism/channel"
 require "futurism/helpers"
 
 module Futurism

--- a/lib/futurism.rb
+++ b/lib/futurism.rb
@@ -1,6 +1,5 @@
 require "rails"
 
-
 require "action_cable"
 require "cable_ready"
 require "futurism/configuration"

--- a/lib/futurism/configuration.rb
+++ b/lib/futurism/configuration.rb
@@ -12,11 +12,10 @@ module Futurism
   end
 
   class Configuration
-
     attr_accessor :parent_channel
 
     def initialize
-      @parent_channel = '::ApplicationCable::Channel'
+      @parent_channel = "::ApplicationCable::Channel"
     end
   end
 end

--- a/lib/futurism/configuration.rb
+++ b/lib/futurism/configuration.rb
@@ -1,0 +1,22 @@
+module Futurism
+  class << self
+    def configure
+      yield configuration
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    alias_method :config, :configuration
+  end
+
+  class Configuration
+
+    attr_accessor :parent_channel
+
+    def initialize
+      @parent_channel = '::ApplicationCable::Channel'
+    end
+  end
+end

--- a/lib/futurism/version.rb
+++ b/lib/futurism/version.rb
@@ -1,3 +1,3 @@
 module Futurism
-  VERSION = "1.2.0.pre10"
+  VERSION = "1.2.0.pre9"
 end

--- a/lib/futurism/version.rb
+++ b/lib/futurism/version.rb
@@ -1,3 +1,3 @@
 module Futurism
-  VERSION = "1.2.0.pre9"
+  VERSION = "1.2.0.pre10"
 end


### PR DESCRIPTION
# Feature

## Description

This makes the connection able to use the Application::Connection in the same way reflex does. It is over-ridable. 

## Why should this be added

Now you can inherit your application's Action Cable connection and not have to monkey patch things.

