### PR TITLE
add queue mechanism

### DIFF
--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -1,12 +1,6 @@
 /* global IntersectionObserver, CustomEvent, setTimeout */
 
 const dispatchAppearEvent = (entry, observer = null) => {
-  if (!window.Futurism) {
-    return () => {
-      setTimeout(() => dispatchAppearEvent(entry, observer)(), 1)
-    }
-  }
-
   const target = entry.target ? entry.target : entry
 
   const evt = new CustomEvent('futurism:appear', {
@@ -17,38 +11,26 @@ const dispatchAppearEvent = (entry, observer = null) => {
     }
   })
 
-  return () => {
-    target.dispatchEvent(evt)
-  }
-}
-
-// from https://advancedweb.hu/how-to-implement-an-exponential-backoff-retry-strategy-in-javascript/#rejection-based-retrying
-const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
-
-const callWithRetry = async (fn, depth = 0) => {
-  try {
-    return await fn()
-  } catch (e) {
-    if (depth > 10) {
-      throw e
-    }
-    await wait(1.15 ** depth * 2000)
-
-    return callWithRetry(fn, depth + 1)
-  }
+  target.dispatchEvent(evt)
 }
 
 const observerCallback = (entries, observer) => {
   entries.forEach(async entry => {
     if (!entry.isIntersecting) return
 
-    await callWithRetry(dispatchAppearEvent(entry, observer))
+    observer.disconnect()
+    dispatchAppearEvent(entry, observer)
   })
 }
 
 export const extendElementWithIntersectionObserver = element => {
   Object.assign(element, {
-    observer: new IntersectionObserver(observerCallback.bind(element), {})
+    observer: new IntersectionObserver(
+      observerCallback.bind(element),
+      element.dataset.observerOptions
+        ? JSON.parse(element.dataset.observerOptions)
+        : {}
+    )
   })
 
   if (!element.hasAttribute('keep')) {
@@ -59,6 +41,6 @@ export const extendElementWithIntersectionObserver = element => {
 export const extendElementWithEagerLoading = element => {
   if (element.dataset.eager === 'true') {
     if (element.observer) element.observer.disconnect()
-    callWithRetry(dispatchAppearEvent(element))
+    dispatchAppearEvent(element)
   }
 }

--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -18,19 +18,13 @@ const observerCallback = (entries, observer) => {
   entries.forEach(async entry => {
     if (!entry.isIntersecting) return
 
-    observer.disconnect()
     dispatchAppearEvent(entry, observer)
   })
 }
 
 export const extendElementWithIntersectionObserver = element => {
   Object.assign(element, {
-    observer: new IntersectionObserver(
-      observerCallback.bind(element),
-      element.dataset.observerOptions
-        ? JSON.parse(element.dataset.observerOptions)
-        : {}
-    )
+    observer: new IntersectionObserver(observerCallback.bind(element), {})
   })
 
   if (!element.hasAttribute('keep')) {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Action Cable messaging queue based on similar functionality to what was recently added to StimulusReflex.

Allows transmission or queueing of events - both individual and batch - based on the connection status of the AC subscription.

## Why should this be added

Shrinks codebase size and complexity without reimplementing a falloff mechanism. Instead of retries, why not wait until Action Cable is ready for us to send?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
