### PR TITLE
Update js event name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ For individual models or arbitrary collections, you can pass `record` and `index
 
 ## Events
 
-Once your futurize element has been rendered, the `futurize:appeared` custom event will be called.
+Once your futurize element has been rendered, the `futurism:appeared` custom event will be called.
 
 ## Installation
 Add this line to your application's Gemfile:


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Docs

## Description

The js event name was incorrectly documented in the README. Fixed to match the event name emitted by the code.

## Why should this be added

Users can properly attach to the emitted js event without having to delve into the source to find the correct name.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
