### PR TITLE
Opt out of restoring placeholders for a promoted TF navigation

### DIFF
--- a/javascript/elements/futurism_utils.js
+++ b/javascript/elements/futurism_utils.js
@@ -1,7 +1,7 @@
 /* global IntersectionObserver, CustomEvent, setTimeout */
 
 const dispatchAppearEvent = (entry, observer = null) => {
-  if (!window.Futurism) {
+  if (!window.Futurism?.subscription) {
     return () => {
       setTimeout(() => dispatchAppearEvent(entry, observer)(), 1)
     }

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -56,6 +56,15 @@ const cachePlaceholders = e => {
 }
 
 const restorePlaceholders = e => {
+  // we have to opt out of this if the request leading to this is a TF request
+  // if the TF request has been promoted to an advance action
+  // (data-turbo-action="advance"), this callback will fire inadvertently
+  // but the whole page will not be exchanged as in a regular TD visit
+  if (!!window.Futurism.requestedTurboFrame) {
+    delete window.Futurism.requestedTurboFrame
+    return
+  }
+
   const inNamespace = ([key, _payload]) => key.startsWith('futurism-')
   Object.entries(sessionStorage)
     .filter(inNamespace)
@@ -72,6 +81,15 @@ const restorePlaceholders = e => {
     })
 }
 
+const storeRequestedTurboFrame = e => {
+  const { headers } = e.detail.fetchOptions
+
+  if (!headers['Turbo-Frame'] || headers['X-Sec-Purpose'] === 'prefetch') return
+
+  // we store the frame ID in case the incoming request was referencing one
+  window.Futurism.requestedTurboFrame = headers['Turbo-Frame']
+}
+
 export const initializeElements = () => {
   polyfillCustomElements()
   document.addEventListener('DOMContentLoaded', defineElements)
@@ -80,4 +98,9 @@ export const initializeElements = () => {
   document.addEventListener('turbolinks:load', defineElements)
   document.addEventListener('turbolinks:before-cache', restorePlaceholders)
   document.addEventListener('cable-ready:after-outer-html', cachePlaceholders)
+
+  document.addEventListener(
+    'turbo:before-fetch-request',
+    storeRequestedTurboFrame
+  )
 }

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -60,7 +60,7 @@ const restorePlaceholders = e => {
   // if the TF request has been promoted to an advance action
   // (data-turbo-action="advance"), this callback will fire inadvertently
   // but the whole page will not be exchanged as in a regular TD visit
-  if (!!window.Futurism.requestedTurboFrame) {
+  if (window.Futurism.requestedTurboFrame) {
     delete window.Futurism.requestedTurboFrame
     return
   }

--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -60,8 +60,8 @@ const restorePlaceholders = e => {
   // if the TF request has been promoted to an advance action
   // (data-turbo-action="advance"), this callback will fire inadvertently
   // but the whole page will not be exchanged as in a regular TD visit
-  if (window.Futurism.requestedTurboFrame) {
-    delete window.Futurism.requestedTurboFrame
+  if (sessionStorage.getItem('requested-turbo-frame')) {
+    delete sessionStorage.removeItem('requested-turbo-frame')
     return
   }
 
@@ -87,7 +87,7 @@ const storeRequestedTurboFrame = e => {
   if (!headers['Turbo-Frame'] || headers['X-Sec-Purpose'] === 'prefetch') return
 
   // we store the frame ID in case the incoming request was referencing one
-  window.Futurism.requestedTurboFrame = headers['Turbo-Frame']
+  sessionStorage.setItem('requested-turbo-frame', headers['Turbo-Frame'])
 }
 
 export const initializeElements = () => {

--- a/javascript/futurism_channel.js
+++ b/javascript/futurism_channel.js
@@ -19,7 +19,9 @@ const debounceEvents = (callback, delay = 20) => {
 export const createSubscription = consumer => {
   consumer.subscriptions.create('Futurism::Channel', {
     connected () {
-      window.Futurism = this
+      window.Futurism = {
+        subscription: this
+      }
       document.addEventListener(
         'futurism:appear',
         debounceEvents(events => {


### PR DESCRIPTION
# Bug Fix

## Description

When navigating a part of the page using Turbo Frames, in case of [promoting to a normal page visit](https://turbo.hotwired.dev/handbook/frames#promoting-a-frame-navigation-to-a-page-visit), the placeholders would be replaced but never resolve again.

The reason for this is that the [`turbo:before-cache`](https://turbo.hotwired.dev/reference/events#turbo%3Abefore-cache) event fires on a regular visit, so placeholders will be restored in order to be put into the Turbo cache afterwards. Contrary to a regular page visit, though, the whole page body will **not** be replaced, so the placeholders remain unresolved.

This would have been an easy fix if the `turbo:before-cache` event would have exposed an `event.detail` pointing to something usable, like the targeted Turbo Frame. Since it does not, however, I have come up with the following solution:

1. in a callback to the `turbo:before-fetch-request` event, the requested Turbo Frame ID is stored in the `sessionStorage`
2. the `restorePlaceholders` callback triggered by `turbo:before-cache` will return early if such an identifier is present, then delete it

This could _potentially_ lead to some race conditions, but since this should be tab-isolated, I think it's pretty safe.

Reproduction repository here: https://github.com/julianrubisch/futurism_turbo_frame_placehoder
